### PR TITLE
Changed path parsing to enable multidex support

### DIFF
--- a/code/SmaliAnalyzer.java
+++ b/code/SmaliAnalyzer.java
@@ -15,6 +15,7 @@ import code.io.Arguments;
 public class SmaliAnalyzer {
 
 	private Arguments arguments;
+	private String filterAsPath;
 
 	public SmaliAnalyzer(Arguments arguments) {
 		this.arguments = arguments;
@@ -27,6 +28,7 @@ public class SmaliAnalyzer {
 	}
 
 	public boolean run() {
+		filterAsPath = arguments.getFilter().replaceAll("\\.", File.separator);
 		File projectFolder = getProjectFolder();
 		if (projectFolder.exists()) {
 			traverseSmaliCode(projectFolder);
@@ -40,16 +42,7 @@ public class SmaliAnalyzer {
 	}
 
 	private File getProjectFolder() {
-		File projectFile = new File(arguments.getProjectPath());
-		String pathToAnalyze = projectFile.getAbsolutePath() + File.separator + "smali";
-		if (arguments.getFilter() != null) {
-			String[] packageParts = arguments.getFilter().split("\\.");
-			for (int i = 0; i < packageParts.length; i++) {
-				pathToAnalyze += File.separator + packageParts[i];
-			}
-		}
-
-		return new File(pathToAnalyze);
+		return new File(arguments.getProjectPath());
 	}
 
 	private boolean isInstantRunEnabled() {
@@ -68,17 +61,19 @@ public class SmaliAnalyzer {
 	private void traverseSmaliCode(File folder) {
 		File[] listOfFiles = folder.listFiles();
 		for (int i = 0; i < listOfFiles.length; i++) {
-			if (listOfFiles[i].isFile()) {
-				if (listOfFiles[i].getName().endsWith(".smali")) {
-					processSmaliFile(listOfFiles[i]);
+			File currentFile = listOfFiles[i];
+			if (currentFile.isFile()) {
+				if (currentFile.getName().endsWith(".smali") && currentFile.getAbsolutePath().contains(filterAsPath)) {
+					processSmaliFile(currentFile);
 				}
-			} else if (listOfFiles[i].isDirectory()) {
-				traverseSmaliCode(listOfFiles[i]);
+			} else if (currentFile.isDirectory()) {
+				traverseSmaliCode(currentFile);
 			}
 		}
 	}
 
 	private void processSmaliFile(File file) {
+		System.out.println(file.getAbsolutePath());
 		try (BufferedReader br = new BufferedReader(new FileReader(file))) {
 
 			String fileName = file.getName().substring(0, file.getName().lastIndexOf("."));

--- a/code/SmaliAnalyzer.java
+++ b/code/SmaliAnalyzer.java
@@ -28,7 +28,12 @@ public class SmaliAnalyzer {
 	}
 
 	public boolean run() {
-		filterAsPath = arguments.getFilter().replaceAll("\\.", File.separator);
+		String filter = arguments.getFilter();
+		if (filter == null) {
+			System.err.println("Please check your filter!");
+			return false;
+		}
+		filterAsPath = filter.replaceAll("\\.", File.separator);
 		File projectFolder = getProjectFolder();
 		if (projectFolder.exists()) {
 			traverseSmaliCode(projectFolder);
@@ -36,7 +41,7 @@ public class SmaliAnalyzer {
 		} else if (isInstantRunEnabled()){
 			System.err.println("Enabled Instant Run feature detected. We cannot decompile it. Please, disable Instant Run and rebuild your app.");
 		} else {
-			System.err.println(arguments.getFilter() == null ? "Smali folder cannot be absent!" : "Please check your filter!");
+			System.err.println("Smali folder cannot be absent!");
 		}
 		return false;
 	}

--- a/code/SmaliAnalyzer.java
+++ b/code/SmaliAnalyzer.java
@@ -73,7 +73,6 @@ public class SmaliAnalyzer {
 	}
 
 	private void processSmaliFile(File file) {
-		System.out.println(file.getAbsolutePath());
 		try (BufferedReader br = new BufferedReader(new FileReader(file))) {
 
 			String fileName = file.getName().substring(0, file.getName().lastIndexOf("."));


### PR DESCRIPTION
I modified the project directory parsing a bit to make it work for multidex #12 
It now goes through the project directory and looks for _every_ available smali file and checks than, based on the absolute path, if the package matches.